### PR TITLE
Clean up unused imports

### DIFF
--- a/backend/src/tasks.py
+++ b/backend/src/tasks.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
-from datetime import datetime, timedelta, time
-from typing import List
+from datetime import datetime, timedelta
 
 from celery import Task
 from sqlalchemy import select, delete, and_


### PR DESCRIPTION
## Summary
- remove unused `time` and `List` imports from tasks module

## Testing
- `python -m py_compile backend/src/tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_685b1f529ed48328804a56c10afc6a5e