### PR TITLE
Add basic admin API and Telegram Stars stub

### DIFF
--- a/astrologer-bot/backend/src/config.py
+++ b/astrologer-bot/backend/src/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     telegram_bot_token: str = Field(..., env="TELEGRAM_BOT_TOKEN")
     telegram_webhook_url: Optional[str] = Field(None, env="TELEGRAM_WEBHOOK_URL")
     telegram_payments_token: Optional[str] = Field(None, env="TELEGRAM_PAYMENTS_TOKEN")
+    telegram_stars_token: Optional[str] = Field(None, env="TELEGRAM_STARS_TOKEN")
     
     # Database Configuration
     database_url: str = Field(..., env="DATABASE_URL")
@@ -25,6 +26,10 @@ class Settings(BaseSettings):
     
     # Geocoding API
     geocoding_api_key: Optional[str] = Field(None, env="GEOCODING_API_KEY")
+
+    # Admin credentials
+    admin_username: str = Field("admin", env="ADMIN_USERNAME")
+    admin_password: str = Field("admin", env="ADMIN_PASSWORD")
     
     # Application Configuration
     debug: bool = Field(False, env="DEBUG")

--- a/astrologer-bot/backend/src/main.py
+++ b/astrologer-bot/backend/src/main.py
@@ -3,12 +3,16 @@ import logging
 import os
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+
+from sqlalchemy import select
 
 from src.config import settings
-from src.database import Base, async_engine
+from src.database import Base, async_engine, get_async_db
+from src.models import User, Payment
 from src.handlers.bot import bot
 from src.services.ai_service import ai_service
 
@@ -18,6 +22,21 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+security = HTTPBasic()
+
+
+def verify_admin(credentials: HTTPBasicCredentials = Depends(security)):
+    if (
+        credentials.username == settings.admin_username
+        and credentials.password == settings.admin_password
+    ):
+        return credentials.username
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Unauthorized",
+        headers={"WWW-Authenticate": "Basic"},
+    )
 
 
 @asynccontextmanager
@@ -109,6 +128,53 @@ async def webhook_handler(request: dict):
     except Exception as e:
         logger.error(f"Webhook error: {e}")
         return {"status": "error", "message": str(e)}
+
+
+# -------------------- Admin Endpoints --------------------
+
+@app.post("/admin/login")
+async def admin_login(credentials: HTTPBasicCredentials = Depends(security)):
+    if (
+        credentials.username == settings.admin_username
+        and credentials.password == settings.admin_password
+    ):
+        return {"status": "ok"}
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+
+@app.get("/admin/users")
+async def admin_users(admin: str = Depends(verify_admin)):
+    async with get_async_db() as db:
+        result = await db.execute(select(User))
+        users = result.scalars().all()
+        return [
+            {
+                "id": u.id,
+                "telegram_id": u.telegram_id,
+                "username": u.username,
+                "is_premium": u.is_premium,
+                "created_at": u.created_at,
+            }
+            for u in users
+        ]
+
+
+@app.get("/admin/payments")
+async def admin_payments(admin: str = Depends(verify_admin)):
+    async with get_async_db() as db:
+        result = await db.execute(select(Payment))
+        payments = result.scalars().all()
+        return [
+            {
+                "id": p.id,
+                "user_id": p.user_id,
+                "provider": p.provider,
+                "amount": p.amount,
+                "status": p.status,
+                "paid_at": p.paid_at,
+            }
+            for p in payments
+        ]
 
 
 if __name__ == "__main__":

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,7 @@
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_WEBHOOK_URL=
 TELEGRAM_PAYMENTS_TOKEN=
+TELEGRAM_STARS_TOKEN=
 
 # Database
 DATABASE_URL=postgresql+asyncpg://astrologer:astrologer_password@postgres:5432/astrologer_bot
@@ -15,6 +16,10 @@ AI_MODEL=anthropic/claude-3.5-sonnet
 # Payments
 YOOKASSA_SHOP_ID=
 YOOKASSA_SECRET_KEY=
+
+# Admin credentials
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=admin
 
 # Misc
 GEOCODING_API_KEY=

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     telegram_bot_token: str = Field(..., env="TELEGRAM_BOT_TOKEN")
     telegram_webhook_url: Optional[str] = Field(None, env="TELEGRAM_WEBHOOK_URL")
     telegram_payments_token: Optional[str] = Field(None, env="TELEGRAM_PAYMENTS_TOKEN")
+    telegram_stars_token: Optional[str] = Field(None, env="TELEGRAM_STARS_TOKEN")
     
     # Database Configuration
     database_url: str = Field(..., env="DATABASE_URL")
@@ -25,6 +26,10 @@ class Settings(BaseSettings):
     
     # Geocoding API
     geocoding_api_key: Optional[str] = Field(None, env="GEOCODING_API_KEY")
+
+    # Admin credentials
+    admin_username: str = Field("admin", env="ADMIN_USERNAME")
+    admin_password: str = Field("admin", env="ADMIN_PASSWORD")
     
     # Application Configuration
     debug: bool = Field(False, env="DEBUG")

--- a/backend/src/services/payment_service.py
+++ b/backend/src/services/payment_service.py
@@ -1,0 +1,46 @@
+from typing import Optional
+import logging
+import httpx
+
+from src.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class PaymentService:
+    """Service for Telegram Stars payments."""
+
+    def __init__(self) -> None:
+        self.token = settings.telegram_stars_token
+        self.api_url = f"https://api.telegram.org/bot{self.token}" if self.token else None
+
+    async def create_stars_invoice(self, title: str, description: str, payload: str, amount: int) -> Optional[str]:
+        """Create invoice link using Telegram Stars API.
+
+        Returns the invoice URL or None on failure.
+        """
+        if not self.api_url:
+            logger.warning("Telegram Stars token not configured")
+            return None
+
+        url = f"{self.api_url}/createInvoiceLink"
+        data = {
+            "title": title,
+            "description": description,
+            "payload": payload,
+            "provider_token": self.token,
+            "currency": "USD",
+            "prices": [{"label": title, "amount": amount}],
+        }
+        try:
+            async with httpx.AsyncClient() as client:
+                r = await client.post(url, json=data)
+                r.raise_for_status()
+                resp = r.json()
+                return resp.get("result")
+        except Exception as e:
+            logger.error(f"Failed to create invoice: {e}")
+            return None
+
+
+payment_service = PaymentService()


### PR DESCRIPTION
## Summary
- add Telegram Stars token, admin credentials
- stub PaymentService for Telegram Stars
- expose simple admin API endpoints with basic auth
- update environment example with new variables

## Testing
- `python -m py_compile backend/src/main.py backend/src/services/payment_service.py astrologer-bot/backend/src/main.py astrologer-bot/backend/src/config.py`

------
https://chatgpt.com/codex/tasks/task_e_685bb6c2b9e48328887edcf7a3cfd2fa