### PR TITLE
Update bot env path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 # Environment
 backend/.env
 .env
+bot/.env
 
 # Node
 frontend/node_modules

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ cd astrologer-bot
 Copy the example environment file and edit it with your credentials:
 ```bash
 cp bot/.env.example bot/.env
-nano bot/.env
+nano bot/.env    # edit the new .env file; leave .env.example unchanged
 ```
 Set `TELEGRAM_BOT_TOKEN` and `OPENROUTER_API_KEY`.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ cd astrologer-bot
 cp backend/.env.example backend/.env
 cp bot/.env.example bot/.env
 
-# Edit configuration
+# Edit configuration (edit the new .env files, not the .env.example files)
 nano backend/.env
 nano bot/.env
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,7 +158,7 @@ services:
       context: ./bot
     container_name: astrologer_node_bot
     env_file:
-      - ./bot/.env.example
+      - ./bot/.env
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
## Summary
- docker-compose uses `./bot/.env` for node_bot
- ignore `bot/.env`
- clarify that you edit `bot/.env`, not `.env.example`

## Testing
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eaa7af7c0832881d5c0e8ee62da71