### PR TITLE
Clarify backend .env setup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,12 +17,15 @@ cd astrologer-bot
 ```
 
 ## 2. Configure Environment
-Copy the example environment file and edit it with your credentials:
+Copy the example environment files and edit them with your credentials:
 ```bash
+cp backend/.env.example backend/.env
 cp bot/.env.example bot/.env
+
+nano backend/.env
 nano bot/.env
 ```
-Set `TELEGRAM_BOT_TOKEN` and `OPENROUTER_API_KEY`.
+Set `TELEGRAM_BOT_TOKEN` and `OPENROUTER_API_KEY`. The `backend/.env` file must be in place before running any `docker-compose` commands.
 
 ## 3. Start Bot
 Run the Node.js bot container via Docker Compose:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ cp bot/.env.example bot/.env
 nano backend/.env
 nano bot/.env
 ```
+> **Note**: `backend/.env` must be copied from `.env.example` before running any `docker-compose` commands.
 
 ### 3. Configure Environment Variables
 ```env


### PR DESCRIPTION
## Summary
- mention copying `backend/.env.example` to `backend/.env` in INSTALL instructions
- add quick start note in README that `backend/.env` is required for Docker Compose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eab257ad08328a7888e9fdc0855d1