### PR TITLE
Improve bot startup env checks

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -2,7 +2,19 @@ require('dotenv').config();
 const { Telegraf, Markup } = require('telegraf');
 const axios = require('axios');
 
-const bot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN);
+const botToken = process.env.TELEGRAM_BOT_TOKEN;
+const openrouterKey = process.env.OPENROUTER_API_KEY;
+
+if (!botToken) {
+  console.error('Error: TELEGRAM_BOT_TOKEN is not set. Check your environment.');
+  process.exit(1);
+}
+
+if (!openrouterKey) {
+  console.warn('Warning: OPENROUTER_API_KEY is not configured. AI features will be disabled.');
+}
+
+const bot = new Telegraf(botToken);
 
 // Tarot deck used for simple readings
 const TAROT_CARDS = [


### PR DESCRIPTION
## Summary
- validate required env vars before starting `Telegraf`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685eab30cd08832890c25b2f0f6556c4