### PR TITLE
Clarify usage of telegram libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ A multilingual AI-powered Telegram bot offering comprehensive astrological servi
 
 ## 🏗️ Architecture
 
-### Backend Stack
-- **Node.js 18+** with Telegraf.js for the Telegram bot
-- **Python 3.11+** with FastAPI for API services
+-### Backend Stack
+- **Node.js 18+** with Telegraf.js for the interactive Telegram bot
+- **Python 3.11+** with FastAPI for API services and Celery tasks
+- **python-telegram-bot** for sending scheduled messages from Python
 - **PostgreSQL** for data persistence
 - **Redis** for caching and Celery
 - **Celery** for scheduled tasks
@@ -444,6 +445,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - **Swiss Ephemeris** for astronomical calculations
 - **OpenRouter** for AI model access
 - **Telegraf.js** for Telegram integration
+- **python-telegram-bot** for scheduled Telegram messages
 - **FastAPI** for the web framework
 - **Celery** for task scheduling
 

--- a/backend/src/tasks.py
+++ b/backend/src/tasks.py
@@ -4,6 +4,10 @@ from datetime import datetime, timedelta
 
 from celery import Task
 from sqlalchemy import select, delete, and_
+# Note: Celery tasks use python-telegram-bot to deliver scheduled messages
+# such as daily horoscopes directly from this Python backend. The interactive
+# Telegram bot runs with Telegraf.js in the `bot/` service, so we keep both
+# libraries in the project.
 from telegram import Bot
 
 from src.celery_app import celery_app


### PR DESCRIPTION
## Summary
- document use of python-telegram-bot along with Telegraf.js
- comment in Celery tasks about why python-telegram-bot is still imported

## Testing
- `python -m compileall -q backend/src`
- `npm test --prefix bot` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685eab3bd534832880ca30e5a8188278